### PR TITLE
Use C++ 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required (VERSION 3.24)
 
 project(spffl)
 
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ Standard")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(src)
 add_subdirectory(cli)
 


### PR DESCRIPTION
#6 ran `clang-format` which took out the final space in `template <...<...element_type> >...`

That built fine in CI but didn't build for me on my laptop:

```
a space is required between consecutive right angle brackets (use '> >')
```

Now is as good a time as any to specify a minimum compiler version for this project, which also solves the space/bracket problem.