### PR TITLE
Explicitly specify int32/int64 (first installment)

### DIFF
--- a/cli/spiff/f2npoly_handlers.cpp
+++ b/cli/spiff/f2npoly_handlers.cpp
@@ -206,7 +206,8 @@ void f2npfind_usage(char *argv0) {
 }
 
 int f2npfind_main(int argc, char **argv, usage_t *pusage) {
-  bool do_random = false, deglo, deghi;
+  bool do_random = false;
+  int deglo, deghi;
   f2poly_t m;
 
   if (argc != 4)

--- a/cli/spiff/f2poly_handlers.cpp
+++ b/cli/spiff/f2poly_handlers.cpp
@@ -204,7 +204,8 @@ void f2pfind_usage(char *argv0) {
 }
 
 int f2pfind_main(int argc, char **argv, usage_t *pusage) {
-  bool do_random = false, deglo, deghi;
+  bool do_random = false;
+  int deglo, deghi;
   bool do_irr = false, do_prim = false;
 
   if (argc != 4)

--- a/src/bitrand/psdes.cpp
+++ b/src/bitrand/psdes.cpp
@@ -6,22 +6,23 @@
 
 #include "psdes.h"
 #include <sys/time.h>
+#include <cstdint>
 #include <unistd.h>
 
 // ================================================================
-static unsigned non_reentrant_state0 = 0;
-static unsigned non_reentrant_state1 = 0;
-static unsigned non_reentrant_seeded = 0;
+static uint32_t non_reentrant_state0 = 0;
+static uint32_t non_reentrant_state1 = 0;
+static uint32_t non_reentrant_seeded = 0;
 
 // ----------------------------------------------------------------
-unsigned iran32(void) {
+uint32_t iran32(void) {
   if (!non_reentrant_seeded)
     sran32_tod();
   return iran32_r(non_reentrant_state0, non_reentrant_state1);
 }
 
 // ----------------------------------------------------------------
-void iran64(unsigned &out0, unsigned &out1) {
+void iran64(uint32_t &out0, uint32_t &out1) {
   if (!non_reentrant_seeded)
     sran32_tod();
   return iran64_r(out0, out1, non_reentrant_state0, non_reentrant_state1);
@@ -35,14 +36,14 @@ float fran32(void) {
 }
 
 // ---------------------------------------------------------------;-
-void sran32(unsigned s) {
+void sran32(uint32_t s) {
   non_reentrant_state0 = 0;
   non_reentrant_state1 = s;
   non_reentrant_seeded = 1;
 }
 
 // ---------------------------------------------------------------;-
-void sran32b(unsigned s0, unsigned s1) {
+void sran32b(uint32_t s0, uint32_t s1) {
   non_reentrant_state0 = s0;
   non_reentrant_state1 = s1;
   non_reentrant_seeded = 1;
@@ -58,9 +59,9 @@ void sran32_tod(void) {
 }
 
 // ================================================================
-unsigned iran32_r(unsigned &state0, unsigned &state1) {
-  unsigned word0 = state0;
-  unsigned word1 = state1;
+uint32_t iran32_r(uint32_t &state0, uint32_t &state1) {
+  uint32_t word0 = state0;
+  uint32_t word1 = state1;
   psdes_hash_64(word0, word1);
 
   state1++;
@@ -72,8 +73,7 @@ unsigned iran32_r(unsigned &state0, unsigned &state1) {
 }
 
 // ----------------------------------------------------------------
-void iran64_r(unsigned &out0, unsigned &out1, unsigned &state0,
-              unsigned &state1) {
+void iran64_r(uint32_t &out0, uint32_t &out1, uint32_t &state0, uint32_t &state1) {
   out0 = state0;
   out1 = state1;
   psdes_hash_64(out0, out1);
@@ -84,17 +84,17 @@ void iran64_r(unsigned &out0, unsigned &out1, unsigned &state0,
 }
 
 // ----------------------------------------------------------------
-float fran32_r(unsigned &state0, unsigned &state1) {
-  static unsigned jflone = 0x3f800000;
-  static unsigned jflmask = 0x007fffff;
-  unsigned word1 = iran32_r(state0, state1);
+float fran32_r(uint32_t &state0, uint32_t &state1) {
+  static uint32_t jflone = 0x3f800000;
+  static uint32_t jflmask = 0x007fffff;
+  uint32_t word1 = iran32_r(state0, state1);
   // IEEE bit-bang
-  unsigned bits = jflone | (jflmask & word1);
+  uint32_t bits = jflone | (jflmask & word1);
   return (*(float *)&bits) - 1.0;
 }
 
 // ----------------------------------------------------------------
-void sran32_tod_r(unsigned &state0, unsigned &state1) {
+void sran32_tod_r(uint32_t &state0, uint32_t &state1) {
   struct timeval tod;
   (void)gettimeofday(&tod, 0);
   state0 = getpid() ^ tod.tv_usec;
@@ -120,11 +120,11 @@ void sran32_tod_r(unsigned &state0, unsigned &state1) {
 
 #define NITER 4
 
-void psdes_hash_64(unsigned &word0, unsigned &word1) {
-  unsigned i;                           // Round counter
-  unsigned iswap, ia, iah, ial, ib, ic; // Intermediate values
-  static unsigned c1[NITER] = {0xbaa96887, 0x1e17d32c, 0x03bcdc3c, 0x0f33d1b2};
-  static unsigned c2[NITER] = {0x4b0f3b58, 0xe874f0c3, 0x6955c5a6, 0x55a7ca46};
+void psdes_hash_64(uint32_t &word0, uint32_t &word1) {
+  uint32_t i;                           // Round counter
+  uint32_t iswap, ia, iah, ial, ib, ic; // Intermediate values
+  static uint32_t c1[NITER] = {0xbaa96887, 0x1e17d32c, 0x03bcdc3c, 0x0f33d1b2};
+  static uint32_t c2[NITER] = {0x4b0f3b58, 0xe874f0c3, 0x6955c5a6, 0x55a7ca46};
 
   for (i = 0; i < NITER; i++) {
     iswap = word1;

--- a/src/bitrand/psdes.h
+++ b/src/bitrand/psdes.h
@@ -65,7 +65,7 @@
 
 // * Non-reentrant version with default seeds:
 //
-//   unsigned rand;
+//   uint32_t rand;
 //   rand = iran32();
 //   rand = iran32();
 //   rand = iran32();
@@ -77,7 +77,7 @@
 
 // * Non-reentrant version with specified seeds:
 //
-//   unsigned rand;
+//   uint32_t rand;
 //   sran32(1);
 //   // Or, sran32b(0, 1);
 //   rand = iran32();
@@ -93,13 +93,13 @@
 
 // * Reentrant version with time-of-day seeds:
 //
-//   unsigned state0, state1, rand;
+//   uint32_t state0, state1, rand;
 //   sran32_tod_r(1, &state0, &state1);
 //   rand = iran32(&state0, &state1);
 //   rand = iran32(&state0, &state1);
 //   rand = iran32(&state0, &state1);
 //
-//   unsigned state0, state1;
+//   uint32_t state0, state1;
 //   float rand;
 //   sran32(1);
 //   rand = fran32(&state0, &state1);
@@ -108,14 +108,14 @@
 
 // * Reentrant version with specified seeds:
 //
-//   unsigned state0, state1, rand;
+//   uint32_t state0, state1, rand;
 //   state0 = 7;
 //   state1 = 8;
 //   rand = iran32(&state0, &state1);
 //   rand = iran32(&state0, &state1);
 //   rand = iran32(&state0, &state1);
 //
-//   unsigned state0, state1;
+//   uint32_t state0, state1;
 //   float rand;
 //   state0 = 7;
 //   state1 = 8;
@@ -127,6 +127,8 @@
 #ifndef PSDES_H
 #define PSDES_H
 
+#include <cstdint>
+
 // ----------------------------------------------------------------
 // These versions are non-reentrant.
 // Usage:  Nominally, just call iran32() or fran32().  They remember whether
@@ -134,20 +136,20 @@
 // only if you want to force the same generator output each time.
 
 // Uniformly distributed pseudorandom 32-bit integer.
-unsigned iran32(void);
+uint32_t iran32(void);
 
 // Uniformly distributed pseudorandom 64-bit integer.
-void iran64(unsigned &out0, unsigned &out1);
+void iran64(uint32_t &out0, uint32_t &out1);
 
 // Uniformly distributed single-precision float between 0.0 and 1.0.
 float fran32(void);
 
 // Sets lower 32 bits of generator state to the specified value, and sets
 // the upper 32 bits of generator state to 0.
-void sran32(unsigned s);
+void sran32(uint32_t s);
 
 // Sets all 64 bits of generator state to the specified values.
-void sran32b(unsigned s0, unsigned s1);
+void sran32b(uint32_t s0, uint32_t s1);
 
 // Sets all 64 bits of generator state to the values dependent on the
 // Unix PID, time of day in seconds, and time of day in microseconds.
@@ -157,22 +159,22 @@ void sran32_tod(void);
 // These versions are reentrant.
 
 // Uniformly distributed pseudorandom 32-bit integer.
-unsigned iran32_r(unsigned &state0, unsigned &state1);
+uint32_t iran32_r(uint32_t &state0, uint32_t &state1);
 
 // Uniformly distributed pseudorandom 64-bit integer.
-void iran64_r(unsigned &out0, unsigned &out1, unsigned &state0, unsigned &state1);
+void iran64_r(uint32_t &out0, uint32_t &out1, uint32_t &state0, uint32_t &state1);
 
 // Uniformly distributed single-precision float between 0.0 and 1.0.
-float fran32_r(unsigned &state0, unsigned &state1);
+float fran32_r(uint32_t &state0, uint32_t &state1);
 
 // There is no sran32_r() function.  You own the state variables and may
 // assign to them whatever values you wish.
 
 // This puts time-of-day information into your state variables.
-void sran32_tod_r(unsigned &state0, unsigned &state1void);
+void sran32_tod_r(uint32_t &state0, uint32_t &state1void);
 
 // ----------------------------------------------------------------
 // This is the 64-bit pseudo-DES in-place hash.
-void psdes_hash_64(unsigned &word0, unsigned &word1);
+void psdes_hash_64(uint32_t &word0, uint32_t &word1);
 
 #endif // PSDES_H

--- a/src/bits/bit_matrix_t.h
+++ b/src/bits/bit_matrix_t.h
@@ -8,6 +8,7 @@
 #define BIT_MATRIX_T_H
 
 #include "bit_vector_t.h"
+#include <cstdint>
 #include <iostream>
 
 class bit_matrix_t {

--- a/src/bits/bit_t.h
+++ b/src/bits/bit_t.h
@@ -7,6 +7,7 @@
 #ifndef BIT_T_H
 #define BIT_T_H
 
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -133,7 +134,7 @@ public:
   int from_string(char *string);
 
 private:
-  unsigned char residue;
+  uint8_t residue;
 };
 
 #endif // BIT_T_H

--- a/src/bits/bit_vector_t.h
+++ b/src/bits/bit_vector_t.h
@@ -35,6 +35,7 @@
 #define NWORDS_FROM_NBITS(nb) (((nb) + BITS_PER_WORD - 1) >> BITS_SHIFT)
 
 #include "bit_t.h"
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/src/intmath/log2.cpp
+++ b/src/intmath/log2.cpp
@@ -96,7 +96,7 @@ unsigned find_msb_32(unsigned n) {
 }
 
 // ----------------------------------------------------------------
-unsigned find_msb_64(unsigned long long n) {
+unsigned find_msb_64(uint64_t n) {
   unsigned upper = n >> 32;
 
   //	if (n < MSB_TABLE_SIZE)
@@ -142,7 +142,7 @@ unsigned find_lsb_32(unsigned n) {
 }
 
 // ----------------------------------------------------------------
-unsigned find_lsb_64(unsigned long long n) {
+unsigned find_lsb_64(uint64_t n) {
   unsigned lower = n;
   if (lower)
     return find_lsb_32(lower);
@@ -165,13 +165,13 @@ unsigned calc_log2_unsigned(unsigned n, int want_ceil) {
 }
 
 // ----------------------------------------------------------------
-unsigned long long calc_log2_unsigned_ll(unsigned long long n, int want_ceil) {
-  unsigned long long l = (unsigned long long)find_msb_64(n);
+uint64_t calc_log2_unsigned_ll(uint64_t n, int want_ceil) {
+  uint64_t l = (uint64_t)find_msb_64(n);
 
   if (want_ceil == IFLOOR) {
     return l;
   } else {
-    if (((unsigned long long)1LL << l) == n)
+    if (((uint64_t)1LL << l) == n)
       return l;
     else
       return l + 1;

--- a/src/intmath/log2.cpp.table
+++ b/src/intmath/log2.cpp.table
@@ -105,7 +105,7 @@ unsigned find_msb_32(
 
 // ----------------------------------------------------------------
 unsigned find_msb_64(
-	unsigned long long n)
+	uint64_t n)
 {
 	unsigned upper = n >> 32;
 
@@ -158,7 +158,7 @@ unsigned find_lsb_32(
 
 // ----------------------------------------------------------------
 unsigned find_lsb_64(
-	unsigned long long n)
+	uint64_t n)
 {
 	unsigned lower = n;
 	if (lower)
@@ -186,17 +186,17 @@ unsigned calc_log2_unsigned(
 }
 
 // ----------------------------------------------------------------
-unsigned long long calc_log2_unsigned_ll(
-	unsigned long long n,
+uint64_t calc_log2_unsigned_ll(
+	uint64_t n,
 	int want_ceil)
 {
-	unsigned long long l = (unsigned long long)find_msb_64(n);
+	uint64_t l = (uint64_t)find_msb_64(n);
 
 	if (want_ceil == IFLOOR) {
 		return l;
 	}
 	else {
-		if (((unsigned long long)1LL << l) == n)
+		if (((uint64_t)1LL << l) == n)
 			return l;
 		else
 			return l+1;

--- a/src/intmath/log2.h
+++ b/src/intmath/log2.h
@@ -7,19 +7,20 @@
 #ifndef LOG2_H
 #define LOG2_H
 
+#include <cstdint>
 #include "intfc.h"
 
 unsigned find_msb_16(unsigned short n);
 unsigned find_msb_32(unsigned n);
-unsigned find_msb_64(unsigned long long n);
+unsigned find_msb_64(uint64_t n);
 
 unsigned find_lsb_32(unsigned n);
-unsigned find_lsb_64(unsigned long long n);
+unsigned find_lsb_64(uint64_t n);
 
 // want_ceil is either IFLOOR or ICEIL
 unsigned calc_log2_unsigned(unsigned n, int want_ceil);
 
 // TODO: rename
-unsigned long long calc_log2_unsigned_ll(unsigned long long n, int want_ceil);
+uint64_t calc_log2_unsigned_ll(uint64_t n, int want_ceil);
 
 #endif // LOG2_H

--- a/src/random/int_random.cpp
+++ b/src/random/int_random.cpp
@@ -18,13 +18,13 @@
 #endif
 
 // ----------------------------------------------------------------
-unsigned get_random_unsigned(void) { return (unsigned)get_random_int(); }
+uint32_t get_random_unsigned(void) { return (uint32_t)get_random_int(); }
 
 // ----------------------------------------------------------------
-unsigned long long get_random_ull(void) {
-  unsigned lo = get_random_unsigned();
-  unsigned hi = get_random_unsigned();
-  return ((unsigned long long)hi << 32) | (unsigned long long)lo;
+uint64_t get_random_ull(void) {
+  uint32_t lo = get_random_unsigned();
+  uint32_t hi = get_random_unsigned();
+  return ((uint64_t)hi << 32) | (uint64_t)lo;
 }
 
 // ----------------------------------------------------------------

--- a/src/random/int_random.h
+++ b/src/random/int_random.h
@@ -8,7 +8,7 @@
 #define INT_RANDOM_H
 
 unsigned get_random_unsigned(void);
-unsigned long long get_random_ull(void);
+uint64_t get_random_ull(void);
 int get_random_int(void);
 
 #endif // INT_RANDOM_H


### PR DESCRIPTION
When SPFFL was written in 2004-2005, for me at the time `int`/`unsigned` were reliably 32 bits, while `long long`/`unsigned long long` were reliably 64 bits (on systems available to me at the time).

This is of course no longer true.

There's more work to be done -- this one PR of several that can be done -- which makes 32-bit/64-bit explicit in a few spots including `psdes` and `log2`.

Broader context: #1